### PR TITLE
Atualizar README para agilizar processo de bootstrap para novos desenvolvedores

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 
 ## Dependências
 
-- Python 3.8.0
-- Django >= 3.0
-- PostgreSQL 12.2
+- Python 3.8.2
 - Docker Compose
 
 ```sh

--- a/poetry.lock
+++ b/poetry.lock
@@ -130,6 +130,14 @@ psycopg2 = "*"
 whitenoise = "*"
 
 [[package]]
+category = "main"
+description = "Tweak the form field rendering in templates, not in python-level form definitions."
+name = "django-widget-tweaks"
+optional = false
+python-versions = "*"
+version = "1.4.8"
+
+[[package]]
 category = "dev"
 description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
 name = "factory-boy"
@@ -500,7 +508,7 @@ version = "5.0.1"
 brotli = ["brotli"]
 
 [metadata]
-content-hash = "fc8456286f8e5e7010d38fdafb279a32f62f3d2fb213f1ff2d6473ff72951757"
+content-hash = "f710acbbc0c62e7341f58ba5a98816e20a5b3a3bd421f31efd2771968f723f9d"
 python-versions = "3.8.2"
 
 [metadata.files]
@@ -550,6 +558,10 @@ django-extensions = [
 django-heroku = [
     {file = "django-heroku-0.3.1.tar.gz", hash = "sha256:6af4bc3ae4a9b55eaad6dbe5164918982d2762661aebc9f83d9fa49f6009514e"},
     {file = "django_heroku-0.3.1-py2.py3-none-any.whl", hash = "sha256:2bc690aab89eedbe01311752320a9a12e7548e3b0ed102681acc5736a41a4762"},
+]
+django-widget-tweaks = [
+    {file = "django-widget-tweaks-1.4.8.tar.gz", hash = "sha256:9f91ca4217199b7671971d3c1f323a2bec71a0c27dec6260b3c006fa541bc489"},
+    {file = "django_widget_tweaks-1.4.8-py2.py3-none-any.whl", hash = "sha256:f80bff4a8a59b278bb277a405a76a8b9a884e4bae7a6c70e78a39c626cd1c836"},
 ]
 factory-boy = [
     {file = "factory_boy-2.12.0-py2.py3-none-any.whl", hash = "sha256:728df59b372c9588b83153facf26d3d28947fc750e8e3c95cefa9bed0e6394ee"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dj-database-url = "^0.5.0"
 dj-static = "^0.0.6"
 gunicorn = "^20.0.4"
 django-heroku = "^0.3.1"
+django-widget-tweaks = "^1.4.8"
 
 [tool.poetry.dev-dependencies]
 django-extensions = "^2.2.9"


### PR DESCRIPTION
## Problema

O README atual diz a necessidade de ter o Django, Postgres e do Python 3.8.0.

Atualmente o projeto roda com o Python 3.8.2. Também não existe a necessidade de especificar bibliotecas por conta do gestor de dependências. Bancos e infraestruturas no geral são gerenciados pelo `docker-compose`, não necessitando especificar a versão do banco.


Também houve uma dificuldade para subir a aplicação no ambiente local por falta de uma lib.

## Proposta de solução

Este PR realiza uma alteração pequena na qual orienta novos desenvolvedores a executar a aplicação necessitando somente do `docker-compose` e `poetry`, sem preocupar com versões de bibliotecas ou banco de dados.

Também foi adicionado a diff ao instalar a lib `django-widget-tweaks` necessária quando não temos o django pré instalado na máquina.

:unicorn: 