### PR TITLE
Adiciona tela para cadastro de Usuários

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 ActiveAdmin.register(User) do
-  permit_params :email, :password, :password_confirmation, :role
+  permit_params :email, :password, :password_confirmation, :role, :hospital_id
 
   controller do
     def update_resource(object, attributes)
@@ -20,6 +20,7 @@ ActiveAdmin.register(User) do
     id_column
     column :email
     column :role
+    column :hospital
     actions
   end
 
@@ -29,6 +30,7 @@ ActiveAdmin.register(User) do
     f.inputs do
       f.input(:email)
       f.input(:role)
+      f.input(:hospital)
       f.input(:password)
       f.input(:password_confirmation)
     end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 ActiveAdmin.register(User) do
-  permit_params :email, :password, :password_confirmation
+  permit_params :email, :password, :password_confirmation, :role
 
   controller do
     def update_resource(object, attributes)
@@ -19,6 +19,7 @@ ActiveAdmin.register(User) do
     selectable_column
     id_column
     column :email
+    column :role
     actions
   end
 
@@ -27,6 +28,7 @@ ActiveAdmin.register(User) do
   form do |f|
     f.inputs do
       f.input(:email)
+      f.input(:role)
       f.input(:password)
       f.input(:password_confirmation)
     end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -2,6 +2,19 @@
 ActiveAdmin.register(User) do
   permit_params :email, :password, :password_confirmation
 
+  controller do
+    def update_resource(object, attributes)
+      attributes.each do |attr|
+        if attr[:password].blank? && attr[:password_confirmation].blank?
+          attr.delete(:password)
+          attr.delete(:password_confirmation)
+        end
+      end
+
+      object.send(:update_attributes, *attributes)
+    end
+  end
+
   index do
     selectable_column
     id_column

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,11 @@ class User < ApplicationRecord
   }
 
   validates :role, presence: true
+  validate :admin_cant_have_hospital
+
+  private
+
+  def admin_cant_have_hospital
+    errors.add(:hospital, 'Administradores não podem ser vinculados à hospitais.') if admin? && hospital.present?
+  end
 end

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -2,7 +2,14 @@ pt-BR:
   activerecord:
     models:
       patient: Paciente
+      user: 
+        one: Usuário
+        other: Usuários
     attributes:
+      user:
+        role: Tipo de usuário
+        password: Senha
+        password_confirmation: Confirmação de Senha
       patient:
         full_name: Nome completo
         birthday: Data de nacimento

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe(ApplicationController, type: :controller) do
   describe 'Redirect to correct page' do
     let(:user) { create(:user) }
-    let(:admin_user) { create(:admin) }
+    let(:admin_user) { create(:admin, hospital: nil) }
 
     context 'when is a common user' do
       it 'return hospitals index page' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe(User, type: :model) do
         expect(user.hospital).to(be_present)
       end
     end
+
+    context 'admin user cant have a hospital' do
+      let(:invalid_admin_user) { build(:admin) }
+      let(:valid_admin_user) { build(:admin, hospital: nil) }
+
+      it { expect(invalid_admin_user).to_not(be_valid) }
+      it { expect(valid_admin_user).to(be_valid) }
+    end
   end
 
   describe('email') do


### PR DESCRIPTION
:chart_with_downwards_trend: Issue: #15

## O que mudou

- Adiciona tela no ActiveAdmin para gestão de novos usuários.

## Motivação :muscle:

Como administrador do sistema eu gostaria de poder adicionar, editar e excluir usuários.

## Solução proposta :wrench:

- Adiciona nova tela para gestão do resource User no ActiveAdmin

## Como testar :policeman:

- Crie um usuário com a `role` admin.
- Faça login no ActiveAdmin `/admin/login`.

## Riscos :warning:

- Nenhum previsto.

## Impactos previstos :boom:

- Nenhum previsto.

## Requisitos para deploy :game_die:

- Nenhum requisito.
